### PR TITLE
Add servo calibration panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 src
 *~
+ESP3D-WEBUI/

--- a/www/index.html
+++ b/www/index.html
@@ -56,6 +56,7 @@
         <file-include w3-include-html="'sub/cameratab.html'"></file-include>
         <file-include w3-include-html="'sub/configtab.html'"></file-include>
         <file-include w3-include-html="'sub/settingstab.html'"></file-include>
+        <file-include w3-include-html="'sub/pentab.html'"></file-include>
       </div>
       <!-- / content -->
     </div>
@@ -114,6 +115,7 @@
     <script src="js/numpad.js"></script>
     <script src="js/parameters.js"></script>
     <script src="js/expresssion.js"></script>
+    <script src="js/servo.js"></script>
     <script src="js/tablet.js"></script>
     <!--endRemoveIf(cleanheader)-->
     <!-- smoosh -->

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -491,6 +491,7 @@ function check_startup_message() {
 
 function show_main_UI() {
     displayUndoNone('main_ui');
+    if (typeof init_pen_panel !== 'undefined') init_pen_panel();
 }
 
 function compareStrings(a, b) {

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -31,6 +31,7 @@ var defaultpreferenceslist = "[{\
                                             \"enable_commands_panel\":\"true\",\
                                             \"enable_autoscroll\":\"true\",\
                                             \"enable_verbose_mode\":\"true\",\
+                                            \"enable_pen_panel\":\"false\",\
                                             \"enable_grbl_probe_panel\":\"false\",\
                                             \"probemaxtravel\":\"40\",\
                                             \"probefeedrate\":\"100\",\
@@ -72,6 +73,7 @@ function initpreferences() {
                                             \"enable_commands_panel\":\"true\",\
                                             \"enable_autoscroll\":\"true\",\
                                             \"enable_verbose_mode\":\"true\",\
+                                            \"enable_pen_panel\":\"false\",\
                                             \"enable_grbl_probe_panel\":\"false\",\
                                             \"probemaxtravel\":\"40\",\
                                             \"probefeedrate\":\"100\",\
@@ -126,6 +128,9 @@ function prefs_toggledisplay(id_source, forcevalue) {
         case 'show_grbl_probe_tab':
             if (id(id_source).checked) displayBlock("grbl_probe_preferences");
             else displayNone("grbl_probe_preferences");
+            break;
+        case 'show_pen_panel':
+            // no additional preferences yet
             break;
     }
 }
@@ -208,6 +213,13 @@ function applypreferenceslist() {
             displayNone('camera_frame_display');
             displayNone('camera_detach_button');
         }
+        if (typeof(preferenceslist[0].enable_pen_panel) !== 'undefined') {
+            if (preferenceslist[0].enable_pen_panel === 'true') displayBlock('pentablink');
+            else {
+                id('maintablink').click();
+                displayNone('pentablink');
+            }
+        } else displayNone('pentablink');
     }
     if (preferenceslist[0].enable_grbl_probe_panel === 'true') {
         displayBlock('grblprobetablink');
@@ -402,6 +414,10 @@ function build_dlg_preferences_list() {
     if (typeof(preferenceslist[0].enable_commands_panel) !== 'undefined') {
         id('show_commands_panel').checked = (preferenceslist[0].enable_commands_panel === 'true');
     } else id('show_commands_panel').checked = false;
+    //pen panel
+    if (typeof(preferenceslist[0].enable_pen_panel) !== 'undefined') {
+        id('show_pen_panel').checked = (preferenceslist[0].enable_pen_panel === 'true');
+    } else id('show_pen_panel').checked = false;
     //autoreport interval
     if (typeof(preferenceslist[0].autoreport_interval) !== 'undefined') {
         id('preferences_autoReport_Interval').value = parseInt(preferenceslist[0].autoreport_interval);
@@ -484,6 +500,7 @@ function build_dlg_preferences_list() {
     prefs_toggledisplay('show_commands_panel');
     prefs_toggledisplay('show_files_panel');
     prefs_toggledisplay('show_grbl_probe_tab');
+    prefs_toggledisplay('show_pen_panel');
 }
 
 function closePreferencesDialog() {
@@ -518,6 +535,7 @@ function closePreferencesDialog() {
             (typeof(preferenceslist[0].interval_status) === 'undefined') ||
             (typeof(preferenceslist[0].enable_autoscroll) === 'undefined') ||
             (typeof(preferenceslist[0].enable_verbose_mode) === 'undefined') ||
+            (typeof(preferenceslist[0].enable_pen_panel) === 'undefined') ||
             (typeof(preferenceslist[0].enable_commands_panel) === 'undefined')) {
             modified = true;
         } else {
@@ -547,6 +565,7 @@ function closePreferencesDialog() {
             if (id('has_tft_usb').checked != (preferenceslist[0].has_TFT_USB === 'true')) modified = true;
             //commands
             if (id('show_commands_panel').checked != (preferenceslist[0].enable_commands_panel === 'true')) modified = true;
+            if (id('show_pen_panel').checked != (preferenceslist[0].enable_pen_panel === 'true')) modified = true;
             //interval positions
             if (id('preferences_autoReport_Interval').value != parseInt(preferenceslist[0].autoReport_interval)) modified = true;
             if (id('preferences_pos_Interval_check').value != parseInt(preferenceslist[0].interval_positions)) modified = true;
@@ -668,6 +687,7 @@ function SavePreferences(current_preferences) {
         saveprefs += "\",\"f_filters\":\"" + id('preferences_filters').value;
         saveprefs += "\",\"enable_autoscroll\":\"" + id('preferences_autoscroll').checked;
         saveprefs += "\",\"enable_verbose_mode\":\"" + id('preferences_verbose_mode').checked;
+        saveprefs += "\",\"enable_pen_panel\":\"" + id('show_pen_panel').checked;
         saveprefs += "\",\"enable_commands_panel\":\"" + id('show_commands_panel').checked + "\"}]";
         preferenceslist = JSON.parse(saveprefs);
     }

--- a/www/js/servo.js
+++ b/www/js/servo.js
@@ -1,0 +1,135 @@
+var servoSettings = {
+    min_pulse_us: 1000,
+    max_pulse_us: 2000,
+    pen_up_percent: 10,
+    pen_down_percent: 90,
+    tool: 'servo'
+};
+
+function init_pen_panel() {
+    loadServoSettings();
+}
+
+function loadServoSettings() {
+    var url = '/servo.json';
+    SendGetHttp(url, function(resp) {
+        try {
+            var data = JSON.parse(resp);
+            if (data.min_pulse_us) servoSettings.min_pulse_us = parseInt(data.min_pulse_us);
+            if (data.max_pulse_us) servoSettings.max_pulse_us = parseInt(data.max_pulse_us);
+            if (data.pen_up_percent) servoSettings.pen_up_percent = parseInt(data.pen_up_percent);
+            if (data.pen_down_percent) servoSettings.pen_down_percent = parseInt(data.pen_down_percent);
+            if (data.tool) servoSettings.tool = data.tool;
+        } catch (e) {
+            console.log('Invalid servo.json');
+        }
+        updateServoUI();
+    }, function(error, resp){
+        updateServoUI();
+    });
+}
+
+function loadServoConfig() {
+    var url = '/config.yaml';
+    var tool = servoSettings.tool;
+    SendGetHttp(url, function(resp) {
+        parseServoConfig(resp, tool);
+        updateServoUI();
+    });
+}
+
+function parseServoConfig(text, tool) {
+    var lines = text.split(/\r?\n/);
+    var inTool = false;
+    var indent = '';
+    for (var i = 0; i < lines.length; i++) {
+        var l = lines[i];
+        if (!inTool) {
+            var m = l.match(new RegExp('^\\s*' + tool + ':\\s*$'));
+            if (m) {
+                inTool = true;
+                indent = l.match(/^\s*/)[0] + '  ';
+            }
+            continue;
+        }
+        if (!l.startsWith(indent)) break;
+        var mm = l.match(/min_pulse_us:\s*(\d+)/);
+        if (mm) servoSettings.min_pulse_us = parseInt(mm[1]);
+        mm = l.match(/max_pulse_us:\s*(\d+)/);
+        if (mm) servoSettings.max_pulse_us = parseInt(mm[1]);
+    }
+}
+
+function updateServoUI() {
+    if (id('servo_min_pulse')) id('servo_min_pulse').value = servoSettings.min_pulse_us;
+    if (id('servo_max_pulse')) id('servo_max_pulse').value = servoSettings.max_pulse_us;
+    if (id('servo_up_percent')) id('servo_up_percent').value = servoSettings.pen_up_percent;
+    if (id('servo_down_percent')) id('servo_down_percent').value = servoSettings.pen_down_percent;
+    if (id('servo_tool')) id('servo_tool').value = servoSettings.tool;
+}
+
+function saveServoSettings() {
+    servoSettings.min_pulse_us = parseInt(id('servo_min_pulse').value);
+    servoSettings.max_pulse_us = parseInt(id('servo_max_pulse').value);
+    servoSettings.pen_up_percent = parseInt(id('servo_up_percent').value);
+    servoSettings.pen_down_percent = parseInt(id('servo_down_percent').value);
+    if (id('servo_tool')) servoSettings.tool = id('servo_tool').value.trim();
+    var blob = new Blob([JSON.stringify(servoSettings, null, ' ')], {type: 'application/json'});
+    var file = new File([blob], 'servo.json');
+    var formData = new FormData();
+    formData.append('path', '/');
+    formData.append('myfile[]', file, 'servo.json');
+    SendFileHttp('/files', formData);
+    saveServoConfig();
+}
+
+function saveServoConfig() {
+    var url = '/config.yaml';
+    SendGetHttp(url, function(resp) {
+        var tool = servoSettings.tool;
+        var lines = resp.split(/\r?\n/);
+        var out = [];
+        var inTool = false;
+        var indent = '';
+        for (var i = 0; i < lines.length; i++) {
+            var l = lines[i];
+            if (!inTool) {
+                out.push(l);
+                var m = l.match(new RegExp('^\\s*' + tool + ':\\s*$'));
+                if (m) {
+                    inTool = true;
+                    indent = l.match(/^\s*/)[0] + '  ';
+                }
+                continue;
+            }
+            if (!l.startsWith(indent)) {
+                out.push(indent + 'min_pulse_us: ' + servoSettings.min_pulse_us);
+                out.push(indent + 'max_pulse_us: ' + servoSettings.max_pulse_us);
+                out.push(l);
+                inTool = false;
+                continue;
+            }
+        }
+        if (inTool) {
+            out.push(indent + 'min_pulse_us: ' + servoSettings.min_pulse_us);
+            out.push(indent + 'max_pulse_us: ' + servoSettings.max_pulse_us);
+        }
+        var blob = new Blob([out.join('\n')], {type: 'text/plain'});
+        var file = new File([blob], 'config.yaml');
+        var formData2 = new FormData();
+        formData2.append('path', '/');
+        formData2.append('myfile[]', file, 'config.yaml');
+        SendFileHttp('/files', formData2);
+    });
+}
+
+function servoCalc(percent) {
+    var minv = parseInt(id('servo_min_pulse').value);
+    var maxv = parseInt(id('servo_max_pulse').value);
+    return Math.round(minv + (maxv - minv) * (percent / 100));
+}
+
+function servoTestMin() { sendCommand('M3 S' + servoCalc(0)); }
+function servoTestMax() { sendCommand('M3 S' + servoCalc(100)); }
+function servoTestUp() { var p = parseInt(id('servo_up_percent').value); sendCommand('M3 S' + servoCalc(p)); }
+function servoTestDown() { var p = parseInt(id('servo_down_percent').value); sendCommand('M3 S' + servoCalc(p)); }

--- a/www/sub/navbar.html
+++ b/www/sub/navbar.html
@@ -42,6 +42,9 @@
         </svg>
         <span translate>FluidNC</span>
     </button>
+    <button class="tablinks hide_it" onclick="opentab(event, 'pentab', 'mainuitabscontent', 'mainuitablinks')" id="pentablink">
+        <span>Pen</span>
+    </button>
     <button class="tablinks" onclick="opentab(event, 'tablettab', 'mainuitabscontent', 'mainuitablinks')" id="tablettablink">
         <span>Tablet</span>
     </button>

--- a/www/sub/pentab.html
+++ b/www/sub/pentab.html
@@ -1,0 +1,34 @@
+<div id="pentab" class="tabcontent">
+    <center><h2>Pen Calibration</h2></center>
+    <table>
+        <tr>
+            <td>Min Pulse (us):</td>
+            <td><input type="number" id="servo_min_pulse" value="1000"></td>
+            <td><button type="button" class="btn btn-default" onclick="servoTestMin()">Test Min Pulse</button></td>
+        </tr>
+        <tr>
+            <td>Max Pulse (us):</td>
+            <td><input type="number" id="servo_max_pulse" value="2000"></td>
+            <td><button type="button" class="btn btn-default" onclick="servoTestMax()">Test Max Pulse</button></td>
+        </tr>
+        <tr>
+            <td>Pen Up Position (%):</td>
+            <td><input type="number" id="servo_up_percent" min="0" max="100" value="10"></td>
+            <td><button type="button" class="btn btn-default" onclick="servoTestUp()">Test Pen Up</button></td>
+        </tr>
+        <tr>
+            <td>Pen Down Position (%):</td>
+            <td><input type="number" id="servo_down_percent" min="0" max="100" value="90"></td>
+            <td><button type="button" class="btn btn-default" onclick="servoTestDown()">Test Pen Down</button></td>
+        </tr>
+        <tr>
+            <td>Tool Name:</td>
+            <td><input type="text" id="servo_tool" value="servo"></td>
+            <td>
+                <button type="button" class="btn btn-default" onclick="loadServoConfig()">Load Config</button>
+                <button type="button" class="btn btn-default" onclick="saveServoConfig()">Save Config</button>
+            </td>
+        </tr>
+    </table>
+    <button type="button" class="btn btn-primary" onclick="saveServoSettings()">Save Settings</button>
+</div>

--- a/www/sub/preferencesdlg.html
+++ b/www/sub/preferencesdlg.html
@@ -438,6 +438,16 @@
                     </div>
                 </div>
             </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" id="show_pen_panel" onclick="prefs_toggledisplay('show_pen_panel')" />
+                            <span>Show pen panel</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
         </div>
         <div class="modal-footer">
             <div class="pull-left" id="preferencesdlg_upload_msg">


### PR DESCRIPTION
## Summary
- add persistent servo settings for pen control
- expose new Pen tab with calibration UI
- load and save servo settings to `servo.json`
- include servo script in main page and initialize after UI load
- make pen panel toggleable via preferences and support config.yaml updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c0eaf4aec83268d3a7fe86d60eff4